### PR TITLE
fixes #30 - now compiles everything with Datum 0.0.36

### DIFF
--- a/DscSample/.build/Tasks/CompileRootConfiguration.ps1
+++ b/DscSample/.build/Tasks/CompileRootConfiguration.ps1
@@ -2,13 +2,14 @@ task CompileRootConfiguration {
 
     $tid = [System.Threading.Thread]::CurrentThread.ManagedThreadId
     Start-Transcript -Path "$BuildOutput\Logs\Compile_Root_Configuration$tid-Log.txt"
+    Import-Module xPSDesiredStateConfiguration
 
     try
     {
         $mofs = . (Join-Path -Path $ProjectPath -ChildPath 'RootConfiguration.ps1')
         Write-Build Green "Successfully compiled $($mofs.Count) MOF files"
     }
-    catch 
+    catch
     {
         Write-Build Red "ERROR OCCURED DURING COMPILATION: $($_.Exception.Message)"
         $relevantErrors = $Error | Where-Object {
@@ -18,5 +19,5 @@ task CompileRootConfiguration {
     }
 
     Stop-Transcript
-    
+
 }

--- a/DscSample/PSDepend.Build.psd1
+++ b/DscSample/PSDepend.Build.psd1
@@ -13,7 +13,7 @@
     Pester            = 'latest'
     PSScriptAnalyzer  = 'latest'
     DscBuildHelpers   = 'latest'
-    Datum             = '0.0.35'
+    Datum             = '0.0.36'
     ProtectedData     = 'latest'
     'powershell-yaml' = 'latest'
 }

--- a/DscSample/RootMetaMof.ps1
+++ b/DscSample/RootMetaMof.ps1
@@ -1,39 +1,41 @@
+#requires -Modules DscBuildHelpers
+
 [DscLocalConfigurationManager()]
 Configuration RootMetaMOF {
     Node $ConfigurationData.AllNodes.GetEnumerator().NodeName {
-        
+
         $LcmConfig = $(Lookup 'LcmConfig\Settings' $Null)
         #If the Nodename is a GUID, use Config ID instead Named config, as per SMB Pull requirements
         if($Node.Nodename -as [Guid]) {$LcmConfig['ConfigurationID'] = $Node.Nodename}
-        Get-DscSplattedResource Settings '' $LcmConfig
+        (Get-DscSplattedResource Settings '' $LcmConfig -NoInvoke).Invoke($LcmConfig)
 
         if($ConfigurationRepositoryShare = $(Lookup 'LcmConfig\ConfigurationRepositoryShare' $Null)) {
-            Get-DscSplattedResource ConfigurationRepositoryShare ConfigurationRepositoryShare $ConfigurationRepositoryShare
+            (Get-DscSplattedResource ConfigurationRepositoryShare ConfigurationRepositoryShare $ConfigurationRepositoryShare -NoInvoke).Invoke($ConfigurationRepositoryShare)
         }
 
         if($ResourceRepositoryShare = $(Lookup 'LcmConfig\ResourceRepositoryShare' $Null)) {
-            Get-DscSplattedResource ResourceRepositoryShare ResourceRepositoryShare $ResourceRepositoryShare
+            (Get-DscSplattedResource ResourceRepositoryShare ResourceRepositoryShare $ResourceRepositoryShare -NoInvoke).Invoke($ResourceRepositoryShare)
         }
 
         if($ConfigurationRepositoryWeb = $(Lookup 'LcmConfig\ConfigurationRepositoryWeb' $Null)) {
             foreach($ConfigRepoName in $ConfigurationRepositoryWeb.keys) {
-                Get-DscSplattedResource ConfigurationRepositoryWeb $ConfigRepoName $ConfigurationRepositoryWeb[$ConfigRepoName]
+                (Get-DscSplattedResource ConfigurationRepositoryWeb $ConfigRepoName $ConfigurationRepositoryWeb[$ConfigRepoName] -NoInvoke).Invoke($ConfigurationRepositoryWeb[$ConfigRepoName])
             }
         }
 
         if($ResourceRepositoryWeb = $(Lookup 'LcmConfig\ResourceRepositoryWeb' $Null)) {
             foreach($ResourceRepoName in $ResourceRepositoryWeb.keys) {
-                Get-DscSplattedResource ResourceRepositoryWeb $ResourceRepoName $ResourceRepositoryWeb[$ResourceRepoName]
+                (Get-DscSplattedResource ResourceRepositoryWeb $ResourceRepoName $ResourceRepositoryWeb[$ResourceRepoName] -NoInvoke).Invoke($ResourceRepositoryWeb[$ResourceRepoName])
             }
         }
 
         if($ReportServerWeb = $(Lookup 'LcmConfig\ReportServerWeb' $Null)) {
-            Get-DscSplattedResource ReportServerWeb ReportServerWeb $ReportServerWeb
+            (Get-DscSplattedResource ReportServerWeb ReportServerWeb $ReportServerWeb -NoInvoke).Invoke($ReportServerWeb)
         }
 
         if($PartialConfiguration = $(Lookup 'LcmConfig\PartialConfiguration' $Null)) {
             foreach($PartialConfigurationName in $PartialConfiguration.keys) {
-                Get-DscSplattedResource PartialConfiguration $PartialConfigurationName $PartialConfiguration[$PartialConfigurationName]
+                (Get-DscSplattedResource PartialConfiguration $PartialConfigurationName $PartialConfiguration[$PartialConfigurationName] -NoInvoke).Invoke($PartialConfiguration[$PartialConfigurationName])
             }
         }
     }


### PR DESCRIPTION
I was using a 'shortcut' for the invocation context which wasn't wise (as I found with the Composites).
Not 100% sure why it was working with 0.0.35 but here's a fix, I think.

At least it compiles for everything for me.
Fix #30 
